### PR TITLE
Add onboarding flow

### DIFF
--- a/lib/core/data/preferences_service.dart
+++ b/lib/core/data/preferences_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PreferencesService {
+  static const _firstLaunchKey = 'firstLaunch';
+  static const _themeModeKey = 'themeMode';
+
+  static Future<bool> isFirstLaunch() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_firstLaunchKey) ?? true;
+  }
+
+  static Future<void> setFirstLaunchFalse() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_firstLaunchKey, false);
+  }
+
+  static Future<ThemeMode> getThemeMode() async {
+    final prefs = await SharedPreferences.getInstance();
+    final value = prefs.getString(_themeModeKey);
+    switch (value) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      default:
+        return ThemeMode.system;
+    }
+  }
+
+  static Future<void> setThemeMode(ThemeMode mode) async {
+    final prefs = await SharedPreferences.getInstance();
+    String value = 'system';
+    if (mode == ThemeMode.light) value = 'light';
+    if (mode == ThemeMode.dark) value = 'dark';
+    await prefs.setString(_themeModeKey, value);
+  }
+}

--- a/lib/features/onboarding/onboarding_controller.dart
+++ b/lib/features/onboarding/onboarding_controller.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/data/preferences_service.dart';
+
+final currentPageProvider = StateProvider<int>((ref) => 0);
+
+class OnboardingController {
+  OnboardingController(this.ref);
+
+  final Ref ref;
+  final PageController pageController = PageController();
+
+  void onPageChanged(int index) {
+    ref.read(currentPageProvider.notifier).state = index;
+  }
+
+  Future<void> next(BuildContext context) async {
+    final page = ref.read(currentPageProvider); // read provider
+    if (page >= 2) {
+      await PreferencesService.setFirstLaunchFalse();
+      if (context.mounted) context.go('/');
+    } else {
+      pageController.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+    }
+  }
+
+  Future<void> skip(BuildContext context) async {
+    await PreferencesService.setFirstLaunchFalse();
+    if (context.mounted) context.go('/');
+  }
+}

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+
+import 'onboarding_controller.dart';
+import 'pages/intro_page.dart';
+import 'pages/permissions_page.dart';
+import 'pages/theme_page.dart';
+
+class OnboardingScreen extends ConsumerWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = OnboardingController(ref);
+    final pages = [
+      IntroPage(controller: controller),
+      PermissionsPage(controller: controller),
+      ThemePage(controller: controller),
+    ];
+
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF121212),
+        elevation: 0,
+        actions: [
+          TextButton(
+            onPressed: () => controller.skip(context),
+            child: const Text('Skip', style: TextStyle(color: Colors.white70)),
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: PageView(
+              controller: controller.pageController,
+              onPageChanged: controller.onPageChanged,
+              children: pages,
+            ),
+          ),
+          const SizedBox(height: 24),
+          SmoothPageIndicator(
+            controller: controller.pageController,
+            count: pages.length,
+            effect: const WormEffect(
+              activeDotColor: Color(0xFF9E4DFF),
+              dotColor: Colors.white24,
+            ),
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/pages/intro_page.dart
+++ b/lib/features/onboarding/pages/intro_page.dart
@@ -1,0 +1,142 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../onboarding_controller.dart';
+
+const primary = Color(0xFF9E4DFF);
+
+class IntroPage extends StatelessWidget {
+  final OnboardingController controller;
+  const IntroPage({super.key, required this.controller});
+
+  List<Widget> _bullet(BuildContext context, String title, String subtitle,
+      IconData icon, Color color) {
+    return [
+      Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            height: 48,
+            width: 48,
+            decoration: BoxDecoration(
+              color: primary.withOpacity(.15),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(icon, color: color),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context)
+                      .textTheme
+                      .headlineSmall
+                      ?.copyWith(color: color),
+                ),
+                Text(
+                  subtitle,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+      const SizedBox(height: 20),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final headline = GoogleFonts.inter(
+      textStyle: Theme.of(context).textTheme.headlineLarge?.copyWith(
+            fontSize: 32,
+            fontWeight: FontWeight.w700,
+          ),
+    );
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const SizedBox(height: 24),
+          Text('Welcome to', style: headline),
+          RichText(
+            text: TextSpan(
+              style: headline,
+              children: const [
+                TextSpan(text: 'Habit'),
+                TextSpan(text: 'Hero', style: TextStyle(color: primary)),
+              ],
+            ),
+          ),
+          const SizedBox(height: 32),
+          ..._bullet(
+            context,
+            'Build new habits',
+            'Create your habits and track your progress',
+            Icons.playlist_add_check,
+            const Color(0xFF9E4DFF),
+          ),
+          ..._bullet(
+            context,
+            'Check it off',
+            'Mark when you completed your habits',
+            Icons.task_alt,
+            const Color(0xFF2CC55D),
+          ),
+          ..._bullet(
+            context,
+            'See the big picture',
+            'Visualise completions in a tile grid',
+            Icons.grid_view_rounded,
+            const Color(0xFF3FA7F6),
+          ),
+          ..._bullet(
+            context,
+            'Get motivation from streaks',
+            'Streak count shows consistency',
+            Icons.local_fire_department,
+            const Color(0xFFFF5D5D),
+          ),
+          ..._bullet(
+            context,
+            'Don\u2019t miss a completion',
+            'Get notifications at set times',
+            Icons.notifications_active,
+            const Color(0xFFF8C231),
+          ),
+          const Spacer(),
+          _PrimaryButton(label: 'Continue', onPressed: () => controller.next(context)),
+        ],
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  const _PrimaryButton({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: primary,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/pages/permissions_page.dart
+++ b/lib/features/onboarding/pages/permissions_page.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+import '../onboarding_controller.dart';
+
+class PermissionsPage extends StatefulWidget {
+  final OnboardingController controller;
+  const PermissionsPage({super.key, required this.controller});
+
+  @override
+  State<PermissionsPage> createState() => _PermissionsPageState();
+}
+
+class _PermissionsPageState extends State<PermissionsPage> {
+  bool allowNotifications = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Expanded(
+            child: Center(
+              child: Icon(Icons.notifications_active,
+                  size: 120, color: Theme.of(context).colorScheme.primary),
+            ),
+          ),
+          Text('Stay on track',
+              style: Theme.of(context).textTheme.headlineLarge),
+          const SizedBox(height: 8),
+          Text('Enable reminders so you never miss a completion',
+              style: Theme.of(context).textTheme.bodyMedium),
+          const SizedBox(height: 24),
+          Card(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: SwitchListTile.adaptive(
+                title: const Text('Allow notifications'),
+                value: allowNotifications,
+                onChanged: (v) => setState(() => allowNotifications = v),
+              ),
+            ),
+          ),
+          const Spacer(),
+          _PrimaryButton(
+            label: 'Continue',
+            onPressed: () => widget.controller.next(context),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  const _PrimaryButton({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF9E4DFF),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../core/data/preferences_service.dart';
+import '../onboarding_controller.dart';
+
+class ThemePage extends StatefulWidget {
+  final OnboardingController controller;
+  const ThemePage({super.key, required this.controller});
+
+  @override
+  State<ThemePage> createState() => _ThemePageState();
+}
+
+class _ThemePageState extends State<ThemePage> {
+  ThemeMode _mode = ThemeMode.system;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Choose your theme',
+              style: Theme.of(context).textTheme.headlineLarge),
+          const SizedBox(height: 16),
+          Card(
+            shape:
+                RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+            child: Column(
+              children: [
+                RadioListTile<ThemeMode>(
+                  title: const Text('System'),
+                  value: ThemeMode.system,
+                  groupValue: _mode,
+                  onChanged: (m) => setState(() => _mode = m!),
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Light'),
+                  value: ThemeMode.light,
+                  groupValue: _mode,
+                  onChanged: (m) => setState(() => _mode = m!),
+                ),
+                RadioListTile<ThemeMode>(
+                  title: const Text('Dark'),
+                  value: ThemeMode.dark,
+                  groupValue: _mode,
+                  onChanged: (m) => setState(() => _mode = m!),
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
+          _PrimaryButton(
+            label: 'Continue',
+            onPressed: () async {
+              await PreferencesService.setThemeMode(_mode);
+              await PreferencesService.setFirstLaunchFalse();
+              if (mounted) context.go('/');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _PrimaryButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  const _PrimaryButton({required this.label, required this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: double.infinity,
+      height: 56,
+      child: ElevatedButton(
+        onPressed: onPressed,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: const Color(0xFF9E4DFF),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        child: Text(label),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,36 +1,30 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
-void main() {
-  runApp(const MyApp());
+import 'core/data/preferences_service.dart';
+import 'routing/app_router.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final firstLaunch = await PreferencesService.isFirstLaunch();
+  final initialRoute = firstLaunch ? '/onboarding' : '/';
+  final router = AppRouter.create(initialRoute);
+  runApp(MyApp(router: router));
 }
 
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  final GoRouter router;
+  const MyApp({super.key, required this.router});
 
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       title: 'Flutter Demo',
+      routerConfig: router,
       theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../main.dart';
+import '../features/onboarding/onboarding_screen.dart';
+
+class AppRouter {
+  static GoRouter create(String initialRoute) {
+    return GoRouter(
+      initialLocation: initialRoute,
+      routes: [
+        GoRoute(
+          path: '/',
+          builder: (context, state) => const MyHomePage(title: 'Flutter Demo Home Page'),
+        ),
+        GoRoute(
+          path: '/onboarding',
+          pageBuilder: (_, __) => const MaterialPage(child: OnboardingScreen()),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,11 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  go_router: ^13.2.0
+  flutter_riverpod: ^2.4.9
+  shared_preferences: ^2.2.2
+  google_fonts: ^6.1.0
+  smooth_page_indicator: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement preference service for firstLaunch and theme mode
- add onboarding controller with Riverpod state
- create intro, permissions, and theme pages
- build onboarding screen with page view and indicator
- add go_router based routing with onboarding route
- load initial route based on first launch in main
- update dependencies

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877874fcb2c8329adf8157e5da2f7ca