### PR TITLE
Fix onboarding imports and ref type

### DIFF
--- a/lib/features/onboarding/onboarding_controller.dart
+++ b/lib/features/onboarding/onboarding_controller.dart
@@ -9,7 +9,7 @@ final currentPageProvider = StateProvider<int>((ref) => 0);
 class OnboardingController {
   OnboardingController(this.ref);
 
-  final Ref ref;
+  final WidgetRef ref;
   final PageController pageController = PageController();
 
   void onPageChanged(int index) {

--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../core/data/preferences_service.dart';
+import '../../../core/data/preferences_service.dart';
 import '../onboarding_controller.dart';
 
 class ThemePage extends StatefulWidget {


### PR DESCRIPTION
## Summary
- correct import path for `PreferencesService` in `ThemePage`
- accept `WidgetRef` in `OnboardingController`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687788e92eec8329a6557b11d149d1f5