### PR TITLE
Implement habit repository and dashboard

### DIFF
--- a/lib/core/data/habit_repository.dart
+++ b/lib/core/data/habit_repository.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'models/habit.dart';
+import 'preferences_service.dart';
+
+class HabitRepository {
+  final _controller = StreamController<List<Habit>>.broadcast();
+  List<Habit> _cache = [];
+
+  HabitRepository() {
+    _load();
+  }
+
+  void _emit() {
+    _controller.add(List.unmodifiable(_cache));
+  }
+
+  Future<void> _load() async {
+    final jsonList = PreferencesService.readHabitListJson();
+    _cache = jsonList.map((e) => Habit.fromJson(e)).toList();
+    _emit();
+  }
+
+  Future<void> _save() async {
+    await PreferencesService
+        .saveHabitListJson(_cache.map((e) => e.toJson()).toList());
+    _emit();
+  }
+
+  Future<List<Habit>> getHabits() async {
+    return List.unmodifiable(_cache);
+  }
+
+  Future<void> addHabit(Habit h) async {
+    _cache.add(h);
+    await _save();
+  }
+
+  Future<void> updateHabit(Habit h) async {
+    final index = _cache.indexWhere((e) => e.id == h.id);
+    if (index != -1) {
+      _cache[index] = h;
+      await _save();
+    }
+  }
+
+  Future<void> deleteHabit(String id) async {
+    _cache.removeWhere((e) => e.id == id);
+    await _save();
+  }
+
+  Future<void> toggleCompletion(String habitId, DateTime date) async {
+    final key = date.toIso8601String().split('T').first;
+    final map = PreferencesService.readCompletionsJson(habitId);
+    if (map.containsKey(key)) {
+      map.remove(key);
+    } else {
+      map[key] = 1;
+    }
+    await PreferencesService.saveCompletionsJson(habitId, map);
+  }
+
+  Stream<List<Habit>> watchHabits() => _controller.stream;
+}

--- a/lib/core/data/models/completion.dart
+++ b/lib/core/data/models/completion.dart
@@ -1,0 +1,23 @@
+class Completion {
+  final String habitId;
+  final DateTime date;
+  final int value;
+
+  Completion(this.habitId, this.date, {this.value = 1});
+
+  factory Completion.fromJson(Map<String, dynamic> j) {
+    return Completion(
+      j['habitId'] as String,
+      DateTime.parse(j['date'] as String),
+      value: j['value'] as int? ?? 1,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'habitId': habitId,
+      'date': date.toIso8601String().split('T').first,
+      'value': value,
+    };
+  }
+}

--- a/lib/core/data/models/habit.dart
+++ b/lib/core/data/models/habit.dart
@@ -1,0 +1,47 @@
+class Habit {
+  final String id;
+  String name;
+  String description;
+  String icon;
+  int colorValue;
+  int targetPerDay;
+  bool archived;
+  DateTime createdAt;
+
+  Habit({
+    required this.id,
+    required this.name,
+    this.description = '',
+    required this.icon,
+    required this.colorValue,
+    this.targetPerDay = 1,
+    this.archived = false,
+    DateTime? createdAt,
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  factory Habit.fromJson(Map<String, dynamic> j) {
+    return Habit(
+      id: j['id'] as String,
+      name: j['name'] as String,
+      description: j['description'] as String? ?? '',
+      icon: j['icon'] as String,
+      colorValue: j['colorValue'] as int,
+      targetPerDay: j['targetPerDay'] as int? ?? 1,
+      archived: j['archived'] as bool? ?? false,
+      createdAt: DateTime.parse(j['createdAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'icon': icon,
+      'colorValue': colorValue,
+      'targetPerDay': targetPerDay,
+      'archived': archived,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+}

--- a/lib/core/data/preferences_service.dart
+++ b/lib/core/data/preferences_service.dart
@@ -1,23 +1,26 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class PreferencesService {
   static const _firstLaunchKey = 'firstLaunch';
   static const _themeModeKey = 'themeMode';
+  static late SharedPreferences _prefs;
+
+  static Future<void> init() async {
+    _prefs = await SharedPreferences.getInstance();
+  }
 
   static Future<bool> isFirstLaunch() async {
-    final prefs = await SharedPreferences.getInstance();
-    return prefs.getBool(_firstLaunchKey) ?? true;
+    return _prefs.getBool(_firstLaunchKey) ?? true;
   }
 
   static Future<void> setFirstLaunchFalse() async {
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setBool(_firstLaunchKey, false);
+    await _prefs.setBool(_firstLaunchKey, false);
   }
 
   static Future<ThemeMode> getThemeMode() async {
-    final prefs = await SharedPreferences.getInstance();
-    final value = prefs.getString(_themeModeKey);
+    final value = _prefs.getString(_themeModeKey);
     switch (value) {
       case 'light':
         return ThemeMode.light;
@@ -29,10 +32,31 @@ class PreferencesService {
   }
 
   static Future<void> setThemeMode(ThemeMode mode) async {
-    final prefs = await SharedPreferences.getInstance();
     String value = 'system';
     if (mode == ThemeMode.light) value = 'light';
     if (mode == ThemeMode.dark) value = 'dark';
-    await prefs.setString(_themeModeKey, value);
+    await _prefs.setString(_themeModeKey, value);
+  }
+
+  static List<Map<String, dynamic>> readHabitListJson() {
+    final str = _prefs.getString('habits');
+    if (str == null || str.isEmpty) return [];
+    final List list = jsonDecode(str) as List;
+    return List<Map<String, dynamic>>.from(list);
+  }
+
+  static Future<void> saveHabitListJson(List<Map<String, dynamic>> list) async {
+    await _prefs.setString('habits', jsonEncode(list));
+  }
+
+  static Map<String, dynamic> readCompletionsJson(String habitId) {
+    final str = _prefs.getString('completions_$habitId');
+    if (str == null || str.isEmpty) return {};
+    return Map<String, dynamic>.from(jsonDecode(str) as Map);
+  }
+
+  static Future<void> saveCompletionsJson(
+      String habitId, Map<String, dynamic> map) async {
+    await _prefs.setString('completions_$habitId', jsonEncode(map));
   }
 }

--- a/lib/core/data/providers.dart
+++ b/lib/core/data/providers.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'habit_repository.dart';
+import 'models/habit.dart';
+
+final habitRepoProvider = Provider<HabitRepository>((ref) => HabitRepository());
+
+final habitListProvider = StreamProvider<List<Habit>>(
+  (ref) => ref.watch(habitRepoProvider).watchHabits(),
+);

--- a/lib/core/streak/streak_service.dart
+++ b/lib/core/streak/streak_service.dart
@@ -1,0 +1,1 @@
+class StreakService {}

--- a/lib/features/dashboard/habit_item_widget.dart
+++ b/lib/features/dashboard/habit_item_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/data/models/habit.dart';
+import '../../core/data/providers.dart';
+import '../../core/data/preferences_service.dart';
+
+class HabitItemWidget extends ConsumerStatefulWidget {
+  final Habit habit;
+  const HabitItemWidget({super.key, required this.habit});
+
+  @override
+  ConsumerState<HabitItemWidget> createState() => _HabitItemWidgetState();
+}
+
+class _HabitItemWidgetState extends ConsumerState<HabitItemWidget> {
+  bool _checked = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final map = PreferencesService.readCompletionsJson(widget.habit.id);
+    final key = DateTime.now().toIso8601String().split('T').first;
+    _checked = map.containsKey(key);
+  }
+
+  Future<void> _toggle(bool? value) async {
+    await ref
+        .read(habitRepoProvider)
+        .toggleCompletion(widget.habit.id, DateTime.now());
+    setState(() {
+      _checked = !_checked;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: Color(widget.habit.colorValue),
+          child: Text(
+            widget.habit.icon,
+            style: const TextStyle(fontSize: 24),
+          ),
+        ),
+        title: Text(
+          widget.habit.name,
+          style: Theme.of(context).textTheme.titleMedium,
+        ),
+        subtitle: const Text('Streak: 0'),
+        trailing: Checkbox(value: _checked, onChanged: _toggle),
+      ),
+    );
+  }
+}

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/data/providers.dart';
+import 'habit_item_widget.dart';
+
+class HomeScreen extends ConsumerWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(habitListProvider).when(
+          data: (habits) {
+            if (habits.isEmpty) return const _EmptyState();
+            return ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: habits.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (_, i) => HabitItemWidget(habit: habits[i]),
+            );
+          },
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (e, _) => Center(child: Text('Error: $e')),
+        );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('No habits yet'));
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'routing/app_router.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await PreferencesService.init();
   final firstLaunch = await PreferencesService.isFirstLaunch();
   final initialRoute = firstLaunch ? '/onboarding' : '/';
   final router = AppRouter.create(initialRoute);

--- a/test/habit_repository_test.dart
+++ b/test/habit_repository_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:habit_hero_app/core/data/habit_repository.dart';
+import 'package:habit_hero_app/core/data/models/habit.dart';
+import 'package:habit_hero_app/core/data/preferences_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await PreferencesService.init();
+  });
+
+  test('addHabit persists and getHabits returns list', () async {
+    final repo = HabitRepository();
+    final habit = Habit(
+      id: '1',
+      name: 'Drink Water',
+      icon: '💧',
+      colorValue: 0xFFFFFFFF,
+    );
+    await repo.addHabit(habit);
+
+    final stored = PreferencesService.readHabitListJson();
+    expect(stored.length, 1);
+    expect(stored.first['id'], habit.id);
+
+    final habits = await repo.getHabits();
+    expect(habits.length, 1);
+    expect(habits.first.id, habit.id);
+  });
+}


### PR DESCRIPTION
## Summary
- add models for Habit and Completion
- update PreferencesService with JSON helpers and initialization
- implement HabitRepository with SharedPreferences persistence
- provide Riverpod providers
- add dashboard views with HabitItemWidget and updated HomeScreen
- initialize preferences in main
- include unit test for HabitRepository

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778940bdc08329ae7c4af86810d8b6