### PR TITLE
Fix onboarding theme and theme mode handling

### DIFF
--- a/lib/core/data/providers.dart
+++ b/lib/core/data/providers.dart
@@ -1,10 +1,32 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'habit_repository.dart';
 import 'models/habit.dart';
+import 'preferences_service.dart';
 
 final habitRepoProvider = Provider<HabitRepository>((ref) => HabitRepository());
 
 final habitListProvider = StreamProvider<List<Habit>>(
   (ref) => ref.watch(habitRepoProvider).watchHabits(),
 );
+
+class ThemeModeNotifier extends StateNotifier<ThemeMode> {
+  ThemeModeNotifier() : super(ThemeMode.system) {
+    _load();
+  }
+
+  Future<void> _load() async {
+    state = await PreferencesService.getThemeMode();
+  }
+
+  Future<void> setTheme(ThemeMode mode) async {
+    state = mode;
+    await PreferencesService.setThemeMode(mode);
+  }
+}
+
+final themeModeProvider =
+    StateNotifierProvider<ThemeModeNotifier, ThemeMode>((ref) {
+  return ThemeModeNotifier();
+});

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -20,11 +20,13 @@ class OnboardingScreen extends ConsumerWidget {
       ThemePage(controller: controller),
     ];
 
-    return Scaffold(
-      backgroundColor: const Color(0xFF121212),
-      appBar: AppBar(
+    return Theme(
+      data: ThemeData.dark(),
+      child: Scaffold(
         backgroundColor: const Color(0xFF121212),
-        elevation: 0,
+        appBar: AppBar(
+          backgroundColor: const Color(0xFF121212),
+          elevation: 0,
         actions: [
           TextButton(
             onPressed: () => controller.skip(context),
@@ -53,6 +55,7 @@ class OnboardingScreen extends ConsumerWidget {
           const SizedBox(height: 24),
         ],
       ),
-    );
+    ),
+  );
   }
 }

--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -1,19 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../../core/data/preferences_service.dart';
+import '../../../core/data/providers.dart';
 import '../onboarding_controller.dart';
 
-class ThemePage extends StatefulWidget {
+class ThemePage extends ConsumerStatefulWidget {
   final OnboardingController controller;
   const ThemePage({super.key, required this.controller});
 
   @override
-  State<ThemePage> createState() => _ThemePageState();
+  ConsumerState<ThemePage> createState() => _ThemePageState();
 }
 
-class _ThemePageState extends State<ThemePage> {
+class _ThemePageState extends ConsumerState<ThemePage> {
   ThemeMode _mode = ThemeMode.system;
+
+  @override
+  void initState() {
+    super.initState();
+    _mode = ref.read(themeModeProvider);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -55,7 +63,7 @@ class _ThemePageState extends State<ThemePage> {
           _PrimaryButton(
             label: 'Continue',
             onPressed: () async {
-              await PreferencesService.setThemeMode(_mode);
+              await ref.read(themeModeProvider.notifier).setTheme(_mode);
               await PreferencesService.setFirstLaunchFalse();
               if (mounted) context.go('/');
             },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import 'core/data/preferences_service.dart';
+import 'core/data/providers.dart';
 import 'routing/app_router.dart';
 
 Future<void> main() async {
@@ -10,22 +12,23 @@ Future<void> main() async {
   final firstLaunch = await PreferencesService.isFirstLaunch();
   final initialRoute = firstLaunch ? '/onboarding' : '/';
   final router = AppRouter.create(initialRoute);
-  runApp(MyApp(router: router));
+  runApp(ProviderScope(child: MyApp(router: router)));
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   final GoRouter router;
   const MyApp({super.key, required this.router});
 
   // This widget is the root of your application.
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final mode = ref.watch(themeModeProvider);
     return MaterialApp.router(
       title: 'Flutter Demo',
       routerConfig: router,
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: mode,
     );
   }
 }


### PR DESCRIPTION
## Summary
- adjust onboarding screen to force dark theme
- manage theme mode with a Riverpod notifier
- apply saved theme in `MyApp`
- update theme selection page to use provider

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68778adace2c8329875b7cef5212b42c