### PR TITLE
Fix navigation to use dashboard home

### DIFF
--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
-import '../main.dart';
+import '../features/dashboard/home_screen.dart';
 import '../features/onboarding/onboarding_screen.dart';
 import '../features/habits/add_edit_habit_screen.dart';
 
@@ -12,7 +12,7 @@ class AppRouter {
       routes: [
         GoRoute(
           path: '/',
-          builder: (context, state) => const MyHomePage(title: 'Flutter Demo Home Page'),
+          builder: (context, state) => const HomeScreen(),
         ),
         GoRoute(
           path: '/onboarding',


### PR DESCRIPTION
## Summary
- route `/` to `HomeScreen`
- adjust router imports accordingly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68778d201fc48329b239d86934e51726