### PR TITLE
Fix onboarding hang

### DIFF
--- a/lib/core/data/habit_repository.dart
+++ b/lib/core/data/habit_repository.dart
@@ -8,6 +8,7 @@ class HabitRepository {
   List<Habit> _cache = [];
 
   HabitRepository() {
+    _controller.onListen = _emit; // emit current cache to new listeners
     _load();
   }
 


### PR DESCRIPTION
## Summary
- ensure `HabitRepository` emits data when a subscriber listens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68778e5ff8788329b6ddf43f8f4f2056