### PR TITLE
Fix theming issues

### DIFF
--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -105,7 +105,7 @@ class _AddEditHabitScreenState extends ConsumerState<AddEditHabitScreen> {
     final theme = Theme.of(context);
     final valid = _nameController.text.trim().isNotEmpty;
     return Scaffold(
-      backgroundColor: const Color(0xFF121212),
+      backgroundColor: Theme.of(context).colorScheme.background,
       body: CustomScrollView(
         slivers: [
           SliverAppBar(
@@ -174,7 +174,7 @@ class _AddEditHabitScreenState extends ConsumerState<AddEditHabitScreen> {
           child: ElevatedButton(
             onPressed: valid ? _save : null,
             style: ElevatedButton.styleFrom(
-              backgroundColor: const Color(0xFF9E4DFF),
+              backgroundColor: Theme.of(context).colorScheme.primary,
               shape: RoundedRectangleBorder(
                 borderRadius: BorderRadius.circular(12),
               ),

--- a/lib/features/onboarding/onboarding_screen.dart
+++ b/lib/features/onboarding/onboarding_screen.dart
@@ -20,17 +20,17 @@ class OnboardingScreen extends ConsumerWidget {
       ThemePage(controller: controller),
     ];
 
-    return Theme(
-      data: ThemeData.dark(),
-      child: Scaffold(
-        backgroundColor: const Color(0xFF121212),
-        appBar: AppBar(
-          backgroundColor: const Color(0xFF121212),
-          elevation: 0,
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.background,
+        elevation: 0,
         actions: [
           TextButton(
             onPressed: () => controller.skip(context),
-            child: const Text('Skip', style: TextStyle(color: Colors.white70)),
+            child: Text('Skip',
+                style: TextStyle(
+                    color: Theme.of(context).colorScheme.primary)),
           ),
         ],
       ),
@@ -47,15 +47,17 @@ class OnboardingScreen extends ConsumerWidget {
           SmoothPageIndicator(
             controller: controller.pageController,
             count: pages.length,
-            effect: const WormEffect(
-              activeDotColor: Color(0xFF9E4DFF),
-              dotColor: Colors.white24,
+            effect: WormEffect(
+              activeDotColor: Theme.of(context).colorScheme.primary,
+              dotColor: Theme.of(context)
+                  .colorScheme
+                  .onSurface
+                  .withOpacity(0.24),
             ),
           ),
           const SizedBox(height: 24),
         ],
       ),
-    ),
-  );
+    );
   }
 }

--- a/lib/features/onboarding/pages/intro_page.dart
+++ b/lib/features/onboarding/pages/intro_page.dart
@@ -3,8 +3,6 @@ import 'package:google_fonts/google_fonts.dart';
 
 import '../onboarding_controller.dart';
 
-const primary = Color(0xFF9E4DFF);
-
 class IntroPage extends StatelessWidget {
   final OnboardingController controller;
   const IntroPage({super.key, required this.controller});
@@ -19,7 +17,7 @@ class IntroPage extends StatelessWidget {
             height: 48,
             width: 48,
             decoration: BoxDecoration(
-              color: primary.withOpacity(.15),
+              color: Theme.of(context).colorScheme.primary.withOpacity(.15),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Icon(icon, color: color),
@@ -67,9 +65,11 @@ class IntroPage extends StatelessWidget {
           RichText(
             text: TextSpan(
               style: headline,
-              children: const [
-                TextSpan(text: 'Habit'),
-                TextSpan(text: 'Hero', style: TextStyle(color: primary)),
+              children: [
+                const TextSpan(text: 'Habit'),
+                TextSpan(
+                    text: 'Hero',
+                    style: TextStyle(color: Theme.of(context).colorScheme.primary)),
               ],
             ),
           ),
@@ -79,7 +79,7 @@ class IntroPage extends StatelessWidget {
             'Build new habits',
             'Create your habits and track your progress',
             Icons.playlist_add_check,
-            const Color(0xFF9E4DFF),
+            Theme.of(context).colorScheme.primary,
           ),
           ..._bullet(
             context,
@@ -130,7 +130,7 @@ class _PrimaryButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor: primary,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(12),
           ),

--- a/lib/features/onboarding/pages/permissions_page.dart
+++ b/lib/features/onboarding/pages/permissions_page.dart
@@ -68,7 +68,7 @@ class _PrimaryButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF9E4DFF),
+          backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
         child: Text(label),

--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -87,7 +87,7 @@ class _PrimaryButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: onPressed,
         style: ElevatedButton.styleFrom(
-          backgroundColor: const Color(0xFF9E4DFF),
+          backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
         child: Text(label),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'core/data/preferences_service.dart';
 import 'core/data/providers.dart';
 import 'routing/app_router.dart';
+import 'theme/app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -26,8 +27,8 @@ class MyApp extends ConsumerWidget {
     return MaterialApp.router(
       title: 'Flutter Demo',
       routerConfig: router,
-      theme: ThemeData.light(),
-      darkTheme: ThemeData.dark(),
+      theme: AppTheme.light(),
+      darkTheme: AppTheme.dark(),
       themeMode: mode,
     );
   }

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class AppTheme {
+  static const Color seedColor = Color(0xFF9E4DFF);
+
+  static ThemeData light() {
+    return ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.light),
+      useMaterial3: true,
+    );
+  }
+
+  static ThemeData dark() {
+    return ThemeData(
+      colorScheme: ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.dark),
+      useMaterial3: true,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create reusable `AppTheme`
- apply `AppTheme` in `main.dart`
- remove hardcoded dark theme from onboarding
- use theme colors in onboarding and habit screens

## Testing
- `apt-get update` *(fails: dart and flutter unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68778ebc9e2c83298a9a5a23c792b1f8