### PR TITLE
Fix part directives and provider listening

### DIFF
--- a/lib/features/dashboard/habit_heatmap_card.dart
+++ b/lib/features/dashboard/habit_heatmap_card.dart
@@ -1,15 +1,5 @@
 part of 'home_screen.dart';
 
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:go_router/go_router.dart';
-
-import '../../core/data/models/habit.dart';
-import '../../core/data/providers.dart';
-import '../../core/data/preferences_service.dart';
-import '../../core/streak/streak_service.dart';
-import 'heatmap_widget.dart';
-
 final _currentHabit = Provider<Habit>((ref) => throw UnimplementedError());
 
 class HabitHeatmapCard extends ConsumerWidget {

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/data/providers.dart';
+import '../../core/data/models/habit.dart';
+import '../../core/data/preferences_service.dart';
+import '../../core/streak/streak_service.dart';
+import 'heatmap_widget.dart';
+import 'package:go_router/go_router.dart';
 part 'habit_heatmap_card.dart';
 
 class HomeScreen extends ConsumerWidget {
@@ -9,10 +14,12 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<String>(newRecordProvider, (_, id) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('🔥 New longest streak!')),
-      );
+    ref.listen<AsyncValue<String>>(newRecordProvider, (_, value) {
+      value.whenData((id) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('🔥 New longest streak!')),
+        );
+      });
     });
 
     return ref.watch(habitListProvider).when(


### PR DESCRIPTION
## Summary
- fix `part of` usage in `habit_heatmap_card.dart`
- add missing imports to `home_screen.dart`
- update listener typing for `newRecordProvider`

## Testing
- `apt-get update`

------
https://chatgpt.com/codex/tasks/task_e_687790184d488329bf194364aacb9049