### PR TITLE
Fix onboarding theme update

### DIFF
--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -42,19 +42,31 @@ class _ThemePageState extends ConsumerState<ThemePage> {
                   title: const Text('System'),
                   value: ThemeMode.system,
                   groupValue: _mode,
-                  onChanged: (m) => setState(() => _mode = m!),
+                  onChanged: (m) {
+                    if (m == null) return;
+                    setState(() => _mode = m);
+                    ref.read(themeModeProvider.notifier).setTheme(m);
+                  },
                 ),
                 RadioListTile<ThemeMode>(
                   title: const Text('Light'),
                   value: ThemeMode.light,
                   groupValue: _mode,
-                  onChanged: (m) => setState(() => _mode = m!),
+                  onChanged: (m) {
+                    if (m == null) return;
+                    setState(() => _mode = m);
+                    ref.read(themeModeProvider.notifier).setTheme(m);
+                  },
                 ),
                 RadioListTile<ThemeMode>(
                   title: const Text('Dark'),
                   value: ThemeMode.dark,
                   groupValue: _mode,
-                  onChanged: (m) => setState(() => _mode = m!),
+                  onChanged: (m) {
+                    if (m == null) return;
+                    setState(() => _mode = m);
+                    ref.read(themeModeProvider.notifier).setTheme(m);
+                  },
                 ),
               ],
             ),


### PR DESCRIPTION
## Summary
- ensure theme changes while selecting radio items in onboarding

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687791a42ffc83298d64ef529a457ae0