### PR TITLE
Implement new HomeScreen UI

### DIFF
--- a/lib/features/dashboard/habit_heatmap_card.dart
+++ b/lib/features/dashboard/habit_heatmap_card.dart
@@ -1,13 +1,11 @@
 part of 'home_screen.dart';
 
-final _currentHabit = Provider<Habit>((ref) => throw UnimplementedError());
-
 class HabitHeatmapCard extends ConsumerWidget {
-  const HabitHeatmapCard({super.key});
+  final Habit habit;
+  const HabitHeatmapCard({super.key, required this.habit});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final habit = ref.watch(_currentHabit);
     final repo = ref.read(habitRepoProvider);
     final map = PreferencesService.readCompletionsJson(habit.id);
     final completions = map.map((k, v) => MapEntry(DateTime.parse(k), v as int));

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -9,11 +9,13 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:habit_hero_app/main.dart';
+import 'package:habit_hero_app/routing/app_router.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    final router = AppRouter.create('/');
+    await tester.pumpWidget(MyApp(router: router));
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- rewrite `home_screen.dart` with Material3 dark theme and new layout
- adjust `HabitHeatmapCard` to accept a `Habit` parameter
- update widget test to build `MyApp` with a router

## Testing
- `dart` tool not available; formatting and tests were not run

------
https://chatgpt.com/codex/tasks/task_e_6877917748848329b3229bfda25d1b45