### PR TITLE
Fix continue button text color

### DIFF
--- a/lib/features/onboarding/pages/intro_page.dart
+++ b/lib/features/onboarding/pages/intro_page.dart
@@ -135,7 +135,10 @@ class _PrimaryButton extends StatelessWidget {
             borderRadius: BorderRadius.circular(12),
           ),
         ),
-        child: Text(label),
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white),
+        ),
       ),
     );
   }

--- a/lib/features/onboarding/pages/permissions_page.dart
+++ b/lib/features/onboarding/pages/permissions_page.dart
@@ -71,7 +71,10 @@ class _PrimaryButton extends StatelessWidget {
           backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
-        child: Text(label),
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white),
+        ),
       ),
     );
   }

--- a/lib/features/onboarding/pages/theme_page.dart
+++ b/lib/features/onboarding/pages/theme_page.dart
@@ -102,7 +102,10 @@ class _PrimaryButton extends StatelessWidget {
           backgroundColor: Theme.of(context).colorScheme.primary,
           shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         ),
-        child: Text(label),
+        child: Text(
+          label,
+          style: const TextStyle(color: Colors.white),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- ensure the onboarding `Continue` buttons use a white text color so the label is visible

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687793e7e6d88329bc21b9703de8edf9