### PR TITLE
Update heatmap UI and add bottom navigation

### DIFF
--- a/lib/features/dashboard/bottom_navbar.dart
+++ b/lib/features/dashboard/bottom_navbar.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+const kCard = Color(0xFF1E1E1E);
+const kAccent = Color(0xFF9E4DFF);
+
+class HomeBottomNav extends StatelessWidget {
+  final int index;
+  final ValueChanged<int> onTap;
+  const HomeBottomNav({super.key, required this.index, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) => BottomNavigationBar(
+        currentIndex: index,
+        onTap: onTap,
+        backgroundColor: kCard,
+        selectedItemColor: kAccent,
+        unselectedItemColor: Colors.white70,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.grid_view), label: ''),
+          BottomNavigationBarItem(icon: Icon(Icons.checklist_rtl), label: ''),
+          BottomNavigationBarItem(icon: Icon(Icons.view_list), label: ''),
+        ],
+      );
+}

--- a/lib/features/dashboard/habit_heatmap_card.dart
+++ b/lib/features/dashboard/habit_heatmap_card.dart
@@ -1,5 +1,7 @@
 part of 'home_screen.dart';
 
+const kCard = Color(0xFF1E1E1E);
+
 class HabitHeatmapCard extends ConsumerWidget {
   final Habit habit;
   const HabitHeatmapCard({super.key, required this.habit});
@@ -9,7 +11,8 @@ class HabitHeatmapCard extends ConsumerWidget {
     final repo = ref.read(habitRepoProvider);
     final map = PreferencesService.readCompletionsJson(habit.id);
     final completions = map.map((k, v) => MapEntry(DateTime.parse(k), v as int));
-    final (current, _) = StreakService.compute(completions);
+    final isDoneToday =
+        completions[DateUtils.dateOnly(DateTime.now())] != null;
 
     void showMenu() {
       showModalBottomSheet(
@@ -47,33 +50,61 @@ class HabitHeatmapCard extends ConsumerWidget {
       onLongPress: showMenu,
       onTap: () => context.push('/edit/${habit.id}'),
       child: Card(
-        color: const Color(0xFF1E1E1E),
+        color: kCard,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
         child: Padding(
           padding: const EdgeInsets.all(16),
-          child: Column(
+          child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Row(
-                children: [
-                  CircleAvatar(
-                    backgroundColor: Color(habit.colorValue),
-                    child: Text(habit.icon, style: const TextStyle(fontSize: 24)),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      habit.name,
-                      style: Theme.of(context).textTheme.titleMedium,
-                    ),
-                  ),
-                  Text('🔥 $current', style: Theme.of(context).textTheme.labelLarge),
-                ],
+              Container(
+                height: 56,
+                width: 56,
+                decoration: BoxDecoration(
+                  color: Color(habit.colorValue),
+                  borderRadius: BorderRadius.circular(8),
+                ),
               ),
-              const SizedBox(height: 12),
-              HeatMapWidget(
-                data: completions,
-                accent: Color(habit.colorValue),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(habit.name,
+                        style: Theme.of(context).textTheme.titleMedium),
+                    if (habit.description.isNotEmpty)
+                      Text(habit.description,
+                          style: Theme.of(context).textTheme.bodySmall),
+                    const SizedBox(height: 8),
+                    HeatMapWidget(
+                      data: completions,
+                      accent: Color(habit.colorValue),
+                    ),
+                  ],
+                ),
+              ),
+              GestureDetector(
+                onTap: () =>
+                    repo.toggleCompletion(habit.id, DateTime.now()),
+                child: Container(
+                  height: 48,
+                  width: 48,
+                  decoration: BoxDecoration(
+                    color:
+                        isDoneToday ? Color(habit.colorValue) : kCard,
+                    border: Border.all(
+                      color: Color(habit.colorValue),
+                      width: 1.5,
+                    ),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Icon(
+                    Icons.check,
+                    color: isDoneToday
+                        ? Colors.white
+                        : Color(habit.colorValue),
+                  ),
+                ),
               ),
             ],
           ),
@@ -82,4 +113,3 @@ class HabitHeatmapCard extends ConsumerWidget {
     );
   }
 }
-

--- a/lib/features/dashboard/heatmap_widget.dart
+++ b/lib/features/dashboard/heatmap_widget.dart
@@ -4,60 +4,92 @@ class HeatMapWidget extends StatelessWidget {
   final Map<DateTime, int> data;
   final Color accent;
   final double tileSize;
+  final double spacing;
 
   const HeatMapWidget({
     super.key,
     required this.data,
     required this.accent,
-    this.tileSize = 14,
+    this.tileSize = 8,
+    this.spacing = 2,
   });
-
-  int get _weeksSpan {
-    if (data.isEmpty) return 12;
-    final dates = data.keys.toList()..sort();
-    final oldest = dates.first;
-    final today = DateUtils.dateOnly(DateTime.now());
-    final diff = today.difference(DateUtils.dateOnly(oldest)).inDays ~/ 7 + 1;
-    return diff.clamp(12, 52);
-  }
 
   @override
   Widget build(BuildContext context) {
-    final weeks = _weeksSpan;
-    return GridView.builder(
-      physics: const NeverScrollableScrollPhysics(),
-      shrinkWrap: true,
-      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
-        crossAxisCount: weeks,
-      ),
-      itemCount: weeks * 7,
-      itemBuilder: (context, index) {
-        final row = index % 7;
-        final col = index ~/ 7;
-        final today = DateUtils.dateOnly(DateTime.now());
-        final start = today.subtract(Duration(days: (weeks - 1 - col) * 7 + (6 - row)));
-        if (start.isAfter(today)) {
-          return const SizedBox.shrink();
-        }
-        final val = data[DateUtils.dateOnly(start)] ?? 0;
-        Color color;
-        if (val == 0) {
-          color = const Color(0xFF1E1E1E);
-        } else if (val == 1) {
-          color = accent.withOpacity(.25);
-        } else {
-          color = accent.withOpacity(.55);
-        }
-        return Container(
-          width: tileSize,
-          height: tileSize,
-          decoration: BoxDecoration(
-            color: start.isAfter(today) ? Colors.transparent : color,
-            border: Border.all(color: Colors.grey.shade600, width: 0.5),
+    final today = DateUtils.dateOnly(DateTime.now());
+    final width = (tileSize + spacing) * 60;
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      physics: const BouncingScrollPhysics(),
+      child: OverflowBox(
+        minWidth: width,
+        maxWidth: width,
+        alignment: Alignment.centerLeft,
+        child: CustomPaint(
+          size: Size(width, (tileSize + spacing) * 7),
+          painter: _HeatMapPainter(
+            data: data,
+            accent: accent,
+            today: today,
+            tileSize: tileSize,
+            spacing: spacing,
           ),
-        );
-      },
+        ),
+      ),
     );
   }
 }
 
+class _HeatMapPainter extends CustomPainter {
+  final Map<DateTime, int> data;
+  final Color accent;
+  final DateTime today;
+  final double tileSize;
+  final double spacing;
+
+  _HeatMapPainter({
+    required this.data,
+    required this.accent,
+    required this.today,
+    required this.tileSize,
+    required this.spacing,
+  });
+
+  static const _bg = Color(0xFF000000);
+
+  DateTime _dateFor(int col, int row) {
+    final days = (59 - col) * 7 + (6 - row);
+    return DateUtils.dateOnly(today.subtract(Duration(days: days)));
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = Radius.circular(2);
+    final paint = Paint();
+
+    for (int c = 0; c < 60; c++) {
+      for (int r = 0; r < 7; r++) {
+        final rect = Rect.fromLTWH(
+          c * (tileSize + spacing),
+          r * (tileSize + spacing),
+          tileSize,
+          tileSize,
+        );
+        final date = _dateFor(c, r);
+        final val = data[date] ?? 0;
+        Color color = _bg.withOpacity(.15);
+        if (val == 1) color = accent.withOpacity(.60);
+        if (val >= 2) color = accent.withOpacity(.95);
+        paint.color = color;
+        canvas.drawRRect(RRect.fromRectAndRadius(rect, radius), paint);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _HeatMapPainter oldDelegate) {
+    return oldDelegate.data != data ||
+        oldDelegate.accent != accent ||
+        oldDelegate.today != today;
+  }
+}

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -7,6 +7,7 @@ import '../../core/data/preferences_service.dart';
 import '../../core/data/providers.dart';
 import '../../core/streak/streak_service.dart';
 import 'heatmap_widget.dart';
+import 'bottom_navbar.dart';
 
 part 'habit_heatmap_card.dart';
 
@@ -68,11 +69,17 @@ class HomeScreen extends ConsumerWidget {
             return asyncHabits.when(
               data: (habits) {
                 if (habits.isEmpty) return const _EmptyState();
-                return ListView.separated(
-                  padding: const EdgeInsets.all(16),
-                  itemCount: habits.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 12),
-                  itemBuilder: (_, i) => HabitHeatmapCard(habit: habits[i]),
+                return SingleChildScrollView(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 80),
+                  child: Column(
+                    children: [
+                      for (int i = 0; i < habits.length; i++) ...[
+                        HabitHeatmapCard(habit: habits[i]),
+                        if (i != habits.length - 1)
+                          const SizedBox(height: 12),
+                      ],
+                    ],
+                  ),
                 );
               },
               loading: () => const Center(child: CircularProgressIndicator()),
@@ -85,6 +92,12 @@ class HomeScreen extends ConsumerWidget {
         onPressed: () => context.push('/add'),
         backgroundColor: accent,
         child: const Icon(Icons.add),
+      ),
+      bottomNavigationBar: HomeBottomNav(
+        index: 0,
+        onTap: (i) {
+          // TODO switch modes
+        },
       ),
     );
   }


### PR DESCRIPTION
## Summary
- redesign heatmap grid using CustomPainter for 60‑column layout
- update habit card with trailing check toggle
- add reusable bottom navigation bar widget
- integrate bottom navigation into home screen and adjust list scrolling

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687795fdce088329aeb326247a13aaa7