### PR TITLE
Fix compile errors in habit heatmap and router

### DIFF
--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -3,6 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/data/providers.dart';
+import '../../core/data/models/habit.dart';
+import '../../core/data/preferences_service.dart';
+import '../../core/streak/streak_service.dart';
 import '../../core/widgets/primary_button.dart';
 import 'empty_state_widget.dart';
 import 'heatmap_widget.dart';
@@ -17,12 +20,12 @@ class HomeScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<String?>(newRecordProvider, (_, id) {
-      if (id != null) {
+    ref.listen<AsyncValue<String>>(newRecordProvider, (_, value) {
+      value.whenData((id) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('🔥 New longest streak!')),
         );
-      }
+      });
     });
 
     return Scaffold(

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -27,7 +27,8 @@ class AppRouter {
         ),
         GoRoute(
           path: '/edit/:id',
-          builder: (_, state) => AddEditHabitScreen(habitId: state.params['id']!),
+          builder: (_, state) =>
+              AddEditHabitScreen(habitId: state.pathParameters['id']!),
         ),
       ],
     );


### PR DESCRIPTION
## Summary
- add missing imports required by `habit_heatmap_card.dart`
- fix `ref.listen` call for `newRecordProvider`
- use `pathParameters` in go router

## Testing
- ❌ `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68779954cea88329be339bd5a620a665